### PR TITLE
Bump chart version for positron to v0.1.3

### DIFF
--- a/charts/positron/Chart.yaml
+++ b/charts/positron/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: positron
 description: A Helm chart for Kubernetes
 type: application
-version: v0.1.2
+version: v0.1.3
 appVersion: "1.16.0"


### PR DESCRIPTION
This PR bumps the chart version for positron to v0.1.3.