### PR TITLE
Bump chart version for positron to v0.1.9

### DIFF
--- a/charts/positron/Chart.yaml
+++ b/charts/positron/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: positron
 description: A Personal Website
 type: application
-version: v0.1.8
+version: v0.1.9

--- a/charts/positron/templates/backend-ingress.yaml
+++ b/charts/positron/templates/backend-ingress.yaml
@@ -24,7 +24,7 @@ spec:
                 port:
                   number: 8000
           - pathType: ImplementationSpecific
-            path: "(/.well-known/.*)"
+            path: "/.well-known/(.*)"
             backend:
               service:
                 name: positron-backend


### PR DESCRIPTION
This PR bumps the chart version for positron to v0.1.9.