### PR TITLE
Bump chart version for positron to v0.1.12

### DIFF
--- a/charts/positron/Chart.yaml
+++ b/charts/positron/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: positron
 description: A Personal Website
 type: application
-version: v0.1.11
+version: v0.1.12


### PR DESCRIPTION
This PR bumps the chart version for positron to v0.1.12.