### PR TITLE
Bump chart version for higgs to v0.1.1

### DIFF
--- a/charts/higgs/Chart.yaml
+++ b/charts/higgs/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: higgs
 description: A Portfolio Website
 type: application
-version: v0.1.0
+version: v0.1.1

--- a/charts/higgs/templates/frontend-deployment.yaml
+++ b/charts/higgs/templates/frontend-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app: {{ .Chart.Name }}-frontend
     spec:
       containers:
-        - image: ghcr.io/profiidev/${{ .Chart.Name }}/{{ .Chart.Name }}-frontend:{{ .Chart.Version }}
+        - image: ghcr.io/profiidev/{{ .Chart.Name }}/{{ .Chart.Name }}-frontend:{{ .Chart.Version }}
           imagePullPolicy: Always
           name: {{ .Chart.Name }}-frontend
           resources:


### PR DESCRIPTION
This PR bumps the chart version for higgs to v0.1.1.