### PR TITLE
Bump chart version for proton to v0.1.10

### DIFF
--- a/charts/proton/Chart.yaml
+++ b/charts/proton/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: proton
 description: A Minecraft Launcher
 type: application
-version: v0.1.9
+version: v0.1.10


### PR DESCRIPTION
This PR bumps the chart version for proton to v0.1.10.